### PR TITLE
Derive the DAML model version from daml.yaml, rather than the DIT version itself.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-ddit"
-version = "0.4.2"
+version = "0.4.5"
 description = "DABL DIT File Tool"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
This change mainly allows the DAML model for a DIT file to stay the same across DIT versions (which is what you want most of the time.)