### PR TITLE
Extend 'ddit inspect' to present details on subdeployments, including artifact size and hash.

### DIFF
--- a/daml_dit_ddit/subcommand_inspect.py
+++ b/daml_dit_ddit/subcommand_inspect.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+from hashlib import sha256
 
 from dataclasses import asdict
 
@@ -14,14 +15,22 @@ from .common import \
     show_package_summary
 
 
-def show_subdeployments(dabl_meta: 'PackageMetadata', files):
+def artifact_hash(artifact_bytes: bytes) -> str:
+    return sha256(artifact_bytes).hexdigest()
+
+
+def show_subdeployments(dabl_meta: 'PackageMetadata', contents):
     subdeployments = dabl_meta.subdeployments
 
     if len(subdeployments or []) > 0:
         print('\nSubdeployments:')
 
         for sd in subdeployments:
-            status = "MISSING" if (sd not in files) else "ok"
+            sd_data = contents.get(sd)
+
+            status = "MISSING" if (sd_data is None) \
+                else f'{len(sd_data)} bytes, {artifact_hash(sd_data)}'
+
             print(f'   {sd} ({status})')
     else:
         print('\nSubdeployments: None')
@@ -31,18 +40,22 @@ def subcommand_main(dit_filename: str):
     if not os.path.exists(dit_filename):
         die(f'DIT file not found: {dit_filename}')
 
+    contents = {}
+
     with ZipFile(dit_filename, 'a') as ditfile:
         filenames = set(ditfile.namelist())
 
-        try:
-            with ditfile.open(DABL_META_NAME) as meta_file:
-                dabl_meta = accept_dabl_meta(meta_file.read())
+        for zi in ditfile.infolist():
+            contents[zi.filename] = ditfile.read(zi)
 
-                show_package_summary(dabl_meta)
-                show_subdeployments(dabl_meta, filenames)
+    try:
+        dabl_meta = accept_dabl_meta(contents[DABL_META_NAME])
 
-        except KeyError:
-            die(f'DIT file missing metadata ({DABL_META_NAME} missing): {dit_filename}')
+        show_package_summary(dabl_meta)
+        show_subdeployments(dabl_meta, contents)
+
+    except KeyError:
+        die(f'DIT file missing metadata ({DABL_META_NAME} missing): {dit_filename}')
 
 
 def setup(sp):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-ddit"
-version = "0.4.5"
+version = "0.4.6"
 description = "DABL DIT File Tool"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
(This information would've been useful diagnosing some GCS issues yesterday.)