### PR TITLE
Add logic to validate a user's Github permissions and report errors appropriately if they are invalid or missing.

### DIFF
--- a/daml_dit_ddit/log.py
+++ b/daml_dit_ddit/log.py
@@ -17,3 +17,6 @@ def setup_default_logging(**overrides):
 
 
 LOG = logging.getLogger('ddit')
+
+def is_verbose():
+    return logging.root.level <= logging.DEBUG

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/digital-asset/daml-dit-ddit"
 keywords = ["daml", "blockchain", "dlt", "distributed ledger", "digital asset"]
 
 [tool.poetry.dependencies]
-python = "3.8.*"
+python = ">=3.8"
 dacite = "*"
 pyyaml = "^5"
 pex = "2.1.18"


### PR DESCRIPTION
This adds two additional checks and corresponding error messages.

This is a normal integration publish:

```
11:29:44 ~/work/arcade/daml-dit-integration-core$ (update-dependencies) $ make publish
ddit release
2021-01-15T16:30:11-0500 [INFO] (ddit) Connected as user: 'Mike Schaeffer' (scopes: {'workflow', 'repo', 'write:packages', 'delete:packages'})
2021-01-15T16:30:11-0500 [INFO] (ddit) Remote URL: 'git@github.com:digital-asset/daml-dit-integration-core.git'
2021-01-15T16:30:11-0500 [INFO] (ddit) Repo name: 'digital-asset/daml-dit-integration-core'
2021-01-15T16:30:11-0500 [INFO] (ddit) Releasing version 0.7.1 as dabl-integration-core-v0.7.1.
2021-01-15T16:30:15-0500 [INFO] (ddit) Creating new release for tag: 'dabl-integration-core-v0.7.1'
2021-01-15T16:30:15-0500 [INFO] (ddit) Uploading release asset: 'dabl-integration-core-0.7.1.dit'
```

This is the error reported with a totally invalid token:

```
11:30:37 ~/work/arcade/daml-dit-integration-core$ (update-dependencies) $ GITHUB_TOKEN=this_is_a_bad_token make publish
ddit release
2021-01-15T16:30:50-0500 [ERROR] (ddit) Fatal Error: Invalid credentials in GITHUB_TOKEN
make: *** [publish] Error 9
```

This is the error reported with a token that does not have proper permissions:

```
11:30:50 ~/work/arcade/daml-dit-integration-core$ (update-dependencies) $ GITHUB_TOKEN=${PERMISSIONLESS_TOKEN} make publish
ddit release
2021-01-15T16:31:13-0500 [INFO] (ddit) Connected as user: 'Mike Schaeffer' (scopes: {''})
2021-01-15T16:31:13-0500 [ERROR] (ddit) Fatal Error: Github token missing required permissions (oauth scopes):{'delete:packages', 'repo', 'write:packages'}
make: *** [publish] Error 9
```

The invalid token case can also be requested to produce a stack backtrace using the toplevel `--verbose` option:

```
11:31:13 ~/work/arcade/daml-dit-integration-core$ (update-dependencies) $ GITHUB_TOKEN=this_is_a_bad_token ddit --verbose release
2021-01-15T16:33:12-0500 [DEBUG] (urllib3.connectionpool) Starting new HTTPS connection (1): api.github.com:443
2021-01-15T16:33:12-0500 [DEBUG] (urllib3.connectionpool) https://api.github.com:443 "GET /user HTTP/1.1" 401 80
2021-01-15T16:33:12-0500 [DEBUG] (github.Requester) GET https://api.github.com/user {'Authorization': 'token (oauth token removed)', 'User-Agent': 'PyGithub/Python'} None ==> 401 {'server': 'GitHub.com', 'date': 'Fri, 15 Jan 2021 16:33:12 GMT', 'content-type': 'application/json; charset=utf-8', 'content-length': '80', 'status': '401 Unauthorized', 'x-github-media-type': 'github.v3; format=json', 'x-ratelimit-limit': '60', 'x-ratelimit-remaining': '48', 'x-ratelimit-reset': '1610728790', 'x-ratelimit-used': '12', 'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset', 'access-control-allow-origin': '*', 'strict-transport-security': 'max-age=31536000; includeSubdomains; preload', 'x-frame-options': 'deny', 'x-content-type-options': 'nosniff', 'x-xss-protection': '1; mode=block', 'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin', 'content-security-policy': "default-src 'none'", 'vary': 'Accept-Encoding, Accept, X-Requested-With', 'x-github-request-id': 'EC61:557C:B60A54:14462CA:6001C3C8'} {"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}
2021-01-15T16:33:12-0500 [ERROR] (ddit) Error authenticating to GitHub.
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/daml_dit_ddit/subcommand_release.py", line 36, in connect_to_github
    username = user.name
  File "/usr/local/lib/python3.9/site-packages/github/AuthenticatedUser.py", line 240, in name
    self._completeIfNotSet(self._name)
  File "/usr/local/lib/python3.9/site-packages/github/GithubObject.py", line 299, in _completeIfNotSet
    self._completeIfNeeded()
  File "/usr/local/lib/python3.9/site-packages/github/GithubObject.py", line 303, in _completeIfNeeded
    self.__complete()
  File "/usr/local/lib/python3.9/site-packages/github/GithubObject.py", line 310, in __complete
    headers, data = self._requester.requestJsonAndCheck("GET", self._url.value)
  File "/usr/local/lib/python3.9/site-packages/github/Requester.py", line 317, in requestJsonAndCheck
    return self.__check(
  File "/usr/local/lib/python3.9/site-packages/github/Requester.py", line 342, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.BadCredentialsException: 401 {"message": "Bad credentials", "documentation_url": "https://docs.github.com/rest"}
2021-01-15T16:33:12-0500 [ERROR] (ddit) Fatal Error: Invalid credentials in GITHUB_TOKEN
```