### PR TITLE
Report ddit version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ clean:
 .PHONY: deps
 deps: $(poetry_install_marker)
 
+.PHONY: setversion
+setversion:
+	gsed -i -E "s/__version__ = '[0-9]+.[0-9]+.[0-9]+'/__version__ = '${version}'/" daml_dit_ddit/__init__.py
+
 .PHONY: publish
 publish: build
 	poetry publish
@@ -42,7 +46,7 @@ version:
 ## Test Targets
 
 .PHONY: typecheck
-typecheck:
+typecheck: setversion
 	poetry run python3 -m mypy -p daml_dit_ddit
 
 .PHONY: test
@@ -58,10 +62,9 @@ $(daml_dit_ddit_bdist): $(poetry_build_marker)
 
 $(daml_dit_ddit_sdist): $(poetry_build_marker)
 
-$(poetry_build_marker): $(build_dir) pyproject.toml $(SRC_FILES)
+$(poetry_build_marker): $(build_dir) pyproject.toml $(SRC_FILES) $(daml_dit_ddit_version)
 	poetry build
 	touch $@
 
 $(poetry_install_marker): $(build_dir) poetry.lock
 	touch $@
-

--- a/daml_dit_ddit/__init__.py
+++ b/daml_dit_ddit/__init__.py
@@ -1,1 +1,2 @@
+__version__ = '0.0.0'
 from .main import main

--- a/daml_dit_ddit/main.py
+++ b/daml_dit_ddit/main.py
@@ -1,6 +1,8 @@
-import argparse
+from . import __version__
 
+import argparse
 import logging
+
 
 from .log import setup_default_logging, LOG
 
@@ -20,6 +22,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--verbose', help='Turn on additional logging.',
                         dest='verbose', action='store_true', default=False)
+    parser.add_argument('--version', action='version', version=__version__)
 
     subcommands={}
     subparsers=parser.add_subparsers(dest='subcommand_name', help='subcommand')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-ddit"
-version = "0.4.7"
+version = "0.4.8"
 description = "DABL DIT File Tool"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
I spent a bit of time trying to figure out the _canonical_ way to do it, and in typical :python: there's 7 ways to do it (https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version), none of which is "right" since we're using Poetry. I couldn't figure out the Poetry way to do it either, so let's hack something together!

I want this just so that we can easily tell which version we're running while developing.