### PR TITLE
Add a command alias to allow the poetry-standard publish command to be used in addition to release.

### DIFF
--- a/daml_dit_ddit/main.py
+++ b/daml_dit_ddit/main.py
@@ -2,6 +2,8 @@ import argparse
 
 import logging
 
+from typing import Union, List
+
 from .log import setup_default_logging, LOG
 
 from .common import die
@@ -24,10 +26,12 @@ def main():
     subcommands={}
     subparsers=parser.add_subparsers(dest='subcommand_name', help='subcommand')
 
-    def install_subcommand(name: str, help: str, setup_fn):
-        cmd_fn = setup_fn(subparsers.add_parser(name, help=help))
+    def install_subcommand(name_or_names: 'Union[str, List[str]]', help: str, setup_fn):
+        names = name_or_names if isinstance(name_or_names, list) else [ name_or_names ]
 
-        subcommands[name] = cmd_fn
+        for name in names:
+            cmd_fn = setup_fn(subparsers.add_parser(name, help=help))
+            subcommands[name] = cmd_fn
 
     install_subcommand('build', 'Build a DIT file.',
                        setup_subcommand_build)
@@ -41,7 +45,7 @@ def main():
     install_subcommand('inspect', 'Inspect the contents of a DIT file.',
                        setup_subcommand_inspect)
 
-    install_subcommand('release', 'Tag and release the current DIT file.',
+    install_subcommand(['publish', 'release'], 'Tag and release the current DIT file.',
                        setup_subcommand_release)
 
     install_subcommand('show', 'Verify and print the current metadata file.',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "daml-dit-ddit"
-version = "0.4.9"
-description = "DABL DIT File Tool"
+version = "0.5.0"
+description = "Daml Hub DIT File Tool"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"
 repository = "https://github.com/digital-asset/daml-dit-ddit"


### PR DESCRIPTION
I honestly got sick of `ddit` working slightly differently than `poetry`.