### PR TITLE
Prevent ddit from packaging multiple copies of the same file

### DIFF
--- a/daml_dit_ddit/subcommand_build.py
+++ b/daml_dit_ddit/subcommand_build.py
@@ -48,20 +48,17 @@ def check_target_file(filename: str, force: bool):
         else:
             die(f'Target file already exists: {filename}')
 
-def file_in_zip(zip: 'ZipFile', name: str):
-    if name in zip.namelist():
-        LOG.warn(f'  File {name} exists in archive -- skipping.')
-        return True
-    else:
-        return False
-
 def pex_writestr(pex: 'ZipFile', filepath: str, filebytes: bytes):
-    if not file_in_zip(pex, filepath):
+    if filepath in pex.namelist():
+        LOG.warn(f'  File {filepath} exists in archive -- skipping.')
+    else:
         pex.writestr(filepath, filebytes)
 
 def pex_write(pex: 'ZipFile', filepath: str, arcname: 'Optional[str]' = None):
     filename = filepath.split("/")[-1]
-    if not file_in_zip(pex, filename):
+    if filename in pex.namelist():
+        LOG.warn(f'  File {filename} exists in archive -- skipping.')
+    else:
         pex.write(filepath, arcname=arcname)
 
 def build_pex(pex_filename: str, local_only: bool):

--- a/daml_dit_ddit/subcommand_build.py
+++ b/daml_dit_ddit/subcommand_build.py
@@ -48,6 +48,15 @@ def check_target_file(filename: str, force: bool):
         else:
             die(f'Target file already exists: {filename}')
 
+def write_pex(pex: 'ZipFile', filepath: str, arcname: 'Optional[str]' = None, filebytes: 'Optional[bytes]' = None):
+    filename = filepath.split("/")[-1]
+    if filename in pex.namelist():
+        LOG.warn(f'File {filename} exists in archive -- skipping.')
+    else:
+        if filebytes:
+            pex.writestr(filename, filebytes)
+        else:
+            pex.write(filename, arcname=arcname)
 
 def build_pex(pex_filename: str, local_only: bool):
     pex_builder = PEXBuilder(include_tools=True)
@@ -272,7 +281,7 @@ def subcommand_main(
                 file_bytes = Path(f'pkg/{pkg_filename}').read_bytes()
 
                 LOG.info(f'  Adding package file: {pkg_filename}, len=={len(file_bytes)}')
-                pexfile.writestr(pkg_filename, file_bytes)
+                write_pex(pexfile, pkg_filename, filebytes=file_bytes)
         else:
             LOG.info('No pkg directory found, not adding any resources.')
 
@@ -280,10 +289,10 @@ def subcommand_main(
             arcname=os.path.basename(sd_filename)
             resource_files.add(arcname)
             LOG.info(f'  Adding package file: {sd_filename} as {arcname}')
-            pexfile.write(sd_filename, arcname=arcname)
+            write_pex(pexfile, sd_filename, arcname=arcname)
 
         if dar_filename:
-            pexfile.write(dar_filename)
+            write_pex(pexfile, dar_filename)
             resource_files.add(dar_filename)
 
             subdeployments=[*subdeployments, dar_filename]
@@ -295,7 +304,7 @@ def subcommand_main(
             daml_model=daml_model_info,
             subdeployments=subdeployments)
 
-        pexfile.writestr(DABL_META_NAME, package_meta_yaml(dabl_meta))
+        write_pex(pexfile, DABL_META_NAME, filebytes=package_meta_yaml(dabl_meta))
 
     for subdeployment in subdeployments:
         if subdeployment not in resource_files:
@@ -336,4 +345,3 @@ def setup(sp):
                     nargs='+', dest='add_subdeployments', default=[])
 
     return subcommand_main
-

--- a/daml_dit_ddit/subcommand_build.py
+++ b/daml_dit_ddit/subcommand_build.py
@@ -54,9 +54,9 @@ def write_pex(pex: 'ZipFile', filepath: str, arcname: 'Optional[str]' = None, fi
         LOG.warn(f'File {filename} exists in archive -- skipping.')
     else:
         if filebytes:
-            pex.writestr(filename, filebytes)
+            pex.writestr(filepath, filebytes)
         else:
-            pex.write(filename, arcname=arcname)
+            pex.write(filepath, arcname=arcname)
 
 def build_pex(pex_filename: str, local_only: bool):
     pex_builder = PEXBuilder(include_tools=True)


### PR DESCRIPTION
We discovered (in the da-marketplace) that `ddit` will package multiple copies of the same subdeployment artifact, if it is included in both the `pkg/` directory and as a parameter to the command `ddit build --subdeployment ...`. 

Done this way, you end up with `*.dit` files that are twice the size they really need to be. The marketplace sample app dit, which sits at around 7 MB normally, becomes 14 MB in size. 

It turns out this is due to the fact that zip files do not enforce file name uniqueness, and `ddit` writes all files in `pkg/` once into the archive, and then additionally writes the subdeployment files into the archive at a later point. 

This PR addresses the issue by ensuring we don't write a file into the archive if a file with that name already exists within it. 