### PR TITLE
Avoid returning None in get_experimental

### DIFF
--- a/daml_dit_ddit/common.py
+++ b/daml_dit_ddit/common.py
@@ -67,7 +67,11 @@ def check_experimental(dabl_meta: 'PackageMetadata'):
             f" inside the tags list of {DABL_META_NAME} instead."))
 
 def get_experimental(catalog: 'CatalogInfo'):
-    return (TAG_EXPERIMENTAL in catalog.tags) or (catalog.experimental)
+    experimental = (TAG_EXPERIMENTAL in catalog.tags) or (catalog.experimental)
+    if experimental is None:
+        return False
+    else:
+        return experimental
 
 def with_catalog(dabl_meta: 'PackageMetadata') -> 'CatalogInfo':
     if dabl_meta.catalog is None:


### PR DESCRIPTION
After some further testing, I found out that the `github_repo.create_git_release` method from PyGithub does not allow the `prerelease` parameter to be `None`. 

```
Traceback (most recent call last):
  File "/Users/alexmatson/Repos/daml-dit-ddit/ddit_v2.px/.bootstrap/pex/pex.py", line 477, in execute
  File "/Users/alexmatson/Repos/daml-dit-ddit/ddit_v2.px/.bootstrap/pex/pex.py", line 394, in _wrap_coverage
  File "/Users/alexmatson/Repos/daml-dit-ddit/ddit_v2.px/.bootstrap/pex/pex.py", line 425, in _wrap_profiling
  File "/Users/alexmatson/Repos/daml-dit-ddit/ddit_v2.px/.bootstrap/pex/pex.py", line 533, in _execute
  File "/Users/alexmatson/Repos/daml-dit-ddit/ddit_v2.px/.bootstrap/pex/pex.py", line 635, in execute_entry
  File "/Users/alexmatson/Repos/daml-dit-ddit/ddit_v2.px/.bootstrap/pex/pex.py", line 651, in execute_pkg_resources
  File "/Users/alexmatson/.pex/installed_wheels/160fb3e0a071adafb178c6db938c0bcd42fde751/daml_dit_ddit-0.5.0-py3-none-any.whl/daml_dit_ddit/main.py", line 67, in main
    cmd_fn(**kwargs)
  File "/Users/alexmatson/.pex/installed_wheels/160fb3e0a071adafb178c6db938c0bcd42fde751/daml_dit_ddit-0.5.0-py3-none-any.whl/daml_dit_ddit/subcommand_release.py", line 130, in subcommand_main
    github_release = github_repo.create_git_release(
  File "/Users/alexmatson/.pex/installed_wheels/d116ab19eede7726ef0c7c7c77afd26e64c76d67/PyGithub-1.54.1-py3-none-any.whl/github/Repository.py", line 1034, in create_git_release
    assert isinstance(prerelease, bool), prerelease
AssertionError: None
```

I updated `get_experimental` to return False directly if it's None. 