### PR TITLE
Add several ddit subcommands for locally running integrations.

### DIFF
--- a/daml_dit_ddit/common.py
+++ b/daml_dit_ddit/common.py
@@ -21,6 +21,11 @@ from daml_dit_api import \
 from .log import LOG
 
 
+VIRTUAL_ENV_DIR = '.ddit-venv'
+
+PYTHON_REQUIREMENT_FILE = 'requirements.txt'
+
+
 def die(message: str) -> 'NoReturn':
     LOG.error(f'Fatal Error: {message}')
     sys.exit(9)
@@ -138,3 +143,18 @@ def read_binary_file(filename: str) -> bytes:
         file_contents = file.read()
 
     return file_contents
+
+def get_itype(integration_type_id):
+    dabl_meta = load_dabl_meta()
+
+    itypes = package_meta_integration_types(dabl_meta)
+
+    itype = itypes.get(integration_type_id)
+
+    if itype is None:
+        show_integration_types(dabl_meta)
+        print()
+        die(f'Unknown integration type: {integration_type_id}\n')
+
+
+    return itype

--- a/daml_dit_ddit/main.py
+++ b/daml_dit_ddit/main.py
@@ -9,10 +9,13 @@ from .log import setup_default_logging, LOG
 from .common import die
 
 from .subcommand_build import setup as setup_subcommand_build
+from .subcommand_clean import setup as setup_subcommand_clean
 from .subcommand_ditversion import setup as setup_subcommand_ditversion
 from .subcommand_genargs import setup as setup_subcommand_genargs
 from .subcommand_inspect import setup as setup_subcommand_inspect
+from .subcommand_install import setup as setup_subcommand_install
 from .subcommand_release import setup as setup_subcommand_release
+from .subcommand_run import setup as setup_subcommand_run
 from .subcommand_show import setup as setup_subcommand_show
 from .subcommand_targetname import setup as setup_subcommand_targetname
 
@@ -33,25 +36,34 @@ def main():
             cmd_fn = setup_fn(subparsers.add_parser(name, help=help))
             subcommands[name] = cmd_fn
 
-    install_subcommand('build', 'Build a DIT file.',
+    install_subcommand("build", "Build a DIT file.",
                        setup_subcommand_build)
 
-    install_subcommand('ditversion', 'Print the current version in dabl-meta.yaml',
+    install_subcommand("clean", "Resets the local build target and virtual environment to an empty state.",
+                       setup_subcommand_clean)
+
+    install_subcommand("ditversion", "Print the current version in dabl-meta.yaml",
                        setup_subcommand_ditversion)
 
-    install_subcommand('genargs', 'Write a template integration argfile to stdout',
+    install_subcommand("genargs", "Write a template integration argfile to stdout",
                        setup_subcommand_genargs)
 
-    install_subcommand('inspect', 'Inspect the contents of a DIT file.',
+    install_subcommand("inspect", "Inspect the contents of a DIT file.",
                        setup_subcommand_inspect)
 
-    install_subcommand(['publish', 'release'], 'Tag and release the current DIT file.',
+    install_subcommand("install", "Install the DIT file's dependencies into a local virtual environment.",
+                       setup_subcommand_install)
+
+    install_subcommand(["publish", "release"], "Tag and release the current DIT file.",
                        setup_subcommand_release)
 
-    install_subcommand('show', 'Verify and print the current metadata file.',
+    install_subcommand("run", "Run the current project as an integration.",
+                       setup_subcommand_run)
+
+    install_subcommand("show", "Verify and print the current metadata file.",
                        setup_subcommand_show)
 
-    install_subcommand('targetname', 'Print the build target filename to stdout',
+    install_subcommand("targetname", "Print the build target filename to stdout",
                        setup_subcommand_targetname)
 
     kwargs = vars(parser.parse_args())

--- a/daml_dit_ddit/subcommand_build.py
+++ b/daml_dit_ddit/subcommand_build.py
@@ -39,12 +39,11 @@ from .common import \
     package_dit_filename, \
     package_meta_integration_types, \
     read_binary_file, \
-    with_catalog
+    with_catalog, \
+    PYTHON_REQUIREMENT_FILE
 
 
 DAML_YAML_NAME = 'daml.yaml'
-
-PYTHON_REQUIREMENT_FILE='requirements.txt'
 
 IF_PROJECT_NAME = 'daml-dit-if'
 

--- a/daml_dit_ddit/subcommand_clean.py
+++ b/daml_dit_ddit/subcommand_clean.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+import shutil
+
+from typing import Optional
+
+from .common import \
+    die, \
+    VIRTUAL_ENV_DIR, \
+    load_dabl_meta, \
+    package_dit_filename
+
+from .log import LOG
+
+def subcommand_main():
+
+    if os.path.isdir(VIRTUAL_ENV_DIR):
+        shutil.rmtree(VIRTUAL_ENV_DIR)
+
+    target_file = package_dit_filename(load_dabl_meta())
+
+    if os.path.isfile(target_file):
+        os.remove(target_file)
+
+
+def setup(sp):
+    return subcommand_main

--- a/daml_dit_ddit/subcommand_genargs.py
+++ b/daml_dit_ddit/subcommand_genargs.py
@@ -5,6 +5,9 @@ from .common import \
     show_integration_types, \
     package_meta_integration_types
 
+from .log import LOG
+
+from .common import get_itype
 
 def generate_argfile(integration_type: 'IntegrationTypeInfo'):
     print('"metadata":')
@@ -14,21 +17,10 @@ def generate_argfile(integration_type: 'IntegrationTypeInfo'):
         print(f'    "{field.id.strip()}": "{field.field_type.strip()}"')
 
 
-def subcommand_main(type_id):
-    dabl_meta = load_dabl_meta()
-
-    itypes = package_meta_integration_types(dabl_meta)
-
-    itype = itypes.get(type_id)
-
-    if itype:
-        generate_argfile(itypes[type_id])
-    else:
-        print(f'Unknown integration type: {type_id}\n')
-
-        show_integration_types(dabl_meta)
+def subcommand_main(integration_type_id):
+    generate_argfile(get_itype(integration_type_id))
 
 
 def setup(sp):
-    sp.add_argument('type_id', metavar='type_id')
+    sp.add_argument('integration_type_id', metavar='integration_type_id')
     return subcommand_main

--- a/daml_dit_ddit/subcommand_install.py
+++ b/daml_dit_ddit/subcommand_install.py
@@ -1,0 +1,66 @@
+import os
+import subprocess
+import venv
+
+from typing import Optional
+
+from .common import \
+    die, \
+    PYTHON_REQUIREMENT_FILE, \
+    VIRTUAL_ENV_DIR
+
+from .log import LOG
+
+
+def install(cmd_suffix):
+    install_cmd = [ f'{VIRTUAL_ENV_DIR}/bin/pip3', 'install' ]
+
+    returncode = subprocess.run([*install_cmd, *cmd_suffix]).returncode
+
+    if returncode != 0:
+        die(f'Error installing {cmd_suffix}')
+
+
+def subcommand_main(force: bool, if_version: 'Optional[str]' = None, if_file: 'Optional[str]' = None):
+
+    if os.path.isdir(VIRTUAL_ENV_DIR):
+        if force:
+            LOG.info(f'Forcibly overwriting virtual environment: {VIRTUAL_ENV_DIR}')
+        else:
+            die(f'Virtual environment already exists: {VIRTUAL_ENV_DIR}')
+    else:
+        LOG.info(f'Installing into virtual environment: {VIRTUAL_ENV_DIR}')
+
+    venv.EnvBuilder(with_pip=True, clear=force).create(VIRTUAL_ENV_DIR)
+
+    if if_version and if_file:
+        die('Cannot specify both --if-version and --if-file')
+
+    elif if_version:
+        LOG.info('Installing specific version of daml-dit-if from PyPi: %r', if_version)
+        install([f'daml_dit_if=={if_version}'])
+
+    elif if_file:
+        LOG.info('Installing daml-dit-if from %r', if_file)
+        install([f'{if_file}'])
+
+    else:
+        LOG.info('Installing latest daml-dit-if from PyPi')
+        install(['daml_dit_if'])
+
+    if os.path.isfile(PYTHON_REQUIREMENT_FILE):
+        install(['-r', 'requirements.txt'])
+
+
+def setup(sp):
+
+    sp.add_argument('--force', help='Forcibly overwrite the virtual environment if it exists.',
+                    dest='force', action='store_true', default=False)
+
+    sp.add_argument('--if-version', help='Use a specific version of daml-dit-if.',
+                    dest='if_version', action='store', default=None)
+
+    sp.add_argument('--if-file', help='Use a specific file source for daml-dit-if.',
+                    dest='if_file', action='store', default=None)
+
+    return subcommand_main

--- a/daml_dit_ddit/subcommand_run.py
+++ b/daml_dit_ddit/subcommand_run.py
@@ -1,0 +1,67 @@
+import os
+import subprocess
+
+from typing import Optional
+
+from .common import \
+    die, \
+    get_itype, \
+    VIRTUAL_ENV_DIR
+
+from .subcommand_install import subcommand_main as subcommand_install
+
+from .log import LOG
+
+
+def subcommand_main(integration_type_id: str, log_level: 'Optional[str]', party: 'Optional[str]',
+                    if_version: 'Optional[str]', if_file: 'Optional[str]'):
+
+    # Ensure that the integration type is known, and print a useful error
+    # message if not.
+    get_itype(integration_type_id)
+
+    if if_file or if_version:
+        # Forcibly ensure the use of a specific version of
+        # daml-dit-if. These options are intended to streamline the cases
+        # of iterating on daml-dit-if or testing an integration on
+        # downlevel versions of the framework that might still be in
+        # use in production Daml Hub.
+        LOG.info(f"Ensuring specific version of daml-dit-if: {if_version or if_file}")
+        subcommand_install(True, if_version, if_file)
+
+    elif not os.path.isdir(VIRTUAL_ENV_DIR):
+        LOG.info("Virtual environment missing, installing now.")
+        subcommand_install(False)
+
+    env = {
+        **os.environ,
+        'PYTHONPATH': 'src',
+        'DABL_INTEGRATION_TYPE_ID': integration_type_id
+    }
+
+    if party:
+        env['DAML_LEDGER_PARTY'] = party
+
+    if log_level:
+        env['DABL_LOG_LEVEL'] = log_level
+
+    subprocess.run([f'{VIRTUAL_ENV_DIR}/bin/python3', '-m', 'daml_dit_if.main'], env=env)
+
+
+def setup(sp):
+    sp.add_argument('integration_type_id', metavar='integration_type_id')
+
+    sp.add_argument('--party', help='Specify the run as party for the integration.',
+                    dest='party', action='store', default=None)
+
+    sp.add_argument('--log-level', help='Set integration log level',
+                    dest='log_level', action='store', default=None)
+
+    sp.add_argument('--if-version', help='Use a specific version of daml-dit-if.',
+                    dest='if_version', action='store', default=None)
+
+    sp.add_argument('--if-file', help='Ensure the integration is run with a specific daml-dit-if.',
+                    dest='if_file', action='store', default=None)
+
+
+    return subcommand_main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-ddit"
-version = "0.5.4"
+version = "0.6.0"
 description = "Daml Hub DIT File Tool"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
This adds `ddit run`, `ddit install`, and `ddit clean`, which are intended to allow management of a local runtime environment for integration testing. The commands are added in the spirit of similar commands in tools like Maven, Gradle, sbt, Leinigen, etc. and are hopefully easy for developers migrating from those tools.

![image](https://user-images.githubusercontent.com/40773844/122924157-7682ab80-d333-11eb-916f-c2d2cb987dbc.png)
