### PR TITLE
add args-file argument to ddit run

### DIFF
--- a/daml_dit_ddit/subcommand_genargs.py
+++ b/daml_dit_ddit/subcommand_genargs.py
@@ -10,8 +10,8 @@ from .log import LOG
 
 from .common import die, get_itype
 
-def generate_argfile(integration_type: 'IntegrationTypeInfo'):
-    with open(INTEGRATION_ARG_FILE, "w") as out:
+def generate_argfile(integration_type: 'IntegrationTypeInfo', args_file: 'str'):
+    with open(args_file, "w") as out:
         out.write(f'# Arguments for integration type \'{integration_type.id}\'\n')
         out.write('\n')
         out.write('"metadata":\n')
@@ -19,23 +19,26 @@ def generate_argfile(integration_type: 'IntegrationTypeInfo'):
             out.write(f'    "{field.id.strip()}": "{field.field_type.strip()}"\n')
 
 
-def subcommand_main(integration_type_id: str, force: bool = False):
+def subcommand_main(integration_type_id: str, args_file: str, force: bool = False):
 
-    if os.path.isfile(INTEGRATION_ARG_FILE):
+    if os.path.isfile(args_file):
         if force:
-            LOG.info(f'Forcibly overwriting existing integration argument file: {INTEGRATION_ARG_FILE}')
-            os.remove(INTEGRATION_ARG_FILE)
+            LOG.info(f'Forcibly overwriting existing integration argument file: {args_file}')
+            os.remove(args_file)
         else:
-            die(f'Integration argument file already exists: {INTEGRATION_ARG_FILE}')
+            die(f'Integration argument file already exists: {args_file}')
 
-    generate_argfile(get_itype(integration_type_id))
+    generate_argfile(get_itype(integration_type_id), args_file)
 
     LOG.info(f'Integration argument file created, please update with configuration'
-             f' values: {INTEGRATION_ARG_FILE}')
+             f' values: {args_file}')
 
 
 def setup(sp):
     sp.add_argument('integration_type_id', metavar='integration_type_id')
+
+    sp.add_argument('--args-file', help=f'Use a specified arguments file, defaults to {INTEGRATION_ARG_FILE}.',
+                    dest='args_file', action='store', default=INTEGRATION_ARG_FILE)
 
     sp.add_argument('--force', help='Forcibly overwrite argument file if it already exists.',
                     dest='force', action='store_true', default=False)

--- a/daml_dit_ddit/subcommand_run.py
+++ b/daml_dit_ddit/subcommand_run.py
@@ -53,7 +53,7 @@ def subcommand_main(
         LOG.info(f'Argument file found: {args_file}')
     else:
         LOG.info(f'Argument file not found: {args_file}')
-        subcommand_genargs(integration_type_id)
+        subcommand_genargs(integration_type_id, args_file)
         die('Cannot run integration with un-edited argument file.')
 
     if if_file or if_version:

--- a/daml_dit_ddit/subcommand_run.py
+++ b/daml_dit_ddit/subcommand_run.py
@@ -27,6 +27,7 @@ def subcommand_main(
         party: 'str',
         if_version: 'Optional[str]',
         if_file: 'Optional[str]',
+        args_file: 'str',
         rebuild_dar: bool):
 
     # Ensure that the integration type is known, and print a useful error
@@ -48,10 +49,10 @@ def subcommand_main(
     with open(RUNTIME_DIT_META_NAME, 'w') as runtime_meta_file:
         runtime_meta_file.write(package_meta_yaml(dabl_meta))
 
-    if os.path.isfile(INTEGRATION_ARG_FILE):
-        LOG.info(f'Argument file found: {INTEGRATION_ARG_FILE}')
+    if os.path.isfile(args_file):
+        LOG.info(f'Argument file found: {args_file}')
     else:
-        LOG.info(f'Argument file not found.')
+        LOG.info(f'Argument file not found: {args_file}')
         subcommand_genargs(integration_type_id)
         die('Cannot run integration with un-edited argument file.')
 
@@ -72,7 +73,7 @@ def subcommand_main(
         **os.environ,
         'PYTHONPATH': 'src',
         'DABL_INTEGRATION_TYPE_ID': integration_type_id,
-        'DABL_INTEGRATION_METADATA_PATH': INTEGRATION_ARG_FILE,
+        'DABL_INTEGRATION_METADATA_PATH': args_file,
         'DAML_DIT_META_PATH': RUNTIME_DIT_META_NAME,
         'DAML_LEDGER_PARTY': party
     }
@@ -100,5 +101,8 @@ def setup(sp):
 
     sp.add_argument('--if-file', help='Ensure the integration is run with a specific daml-dit-if, by file.',
                     dest='if_file', action='store', default=None)
+
+    sp.add_argument('--args-file', help=f'Use a specified arguments file, defaults to {INTEGRATION_ARG_FILE}.',
+                    dest='args_file', action='store', default=INTEGRATION_ARG_FILE)
 
     return subcommand_main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daml-dit-ddit"
-version = "0.6.5"
+version = "0.6.6"
 description = "Daml Hub DIT File Tool"
 authors = ["Mike Schaeffer <mike.schaeffer@digitalasset.com>"]
 readme = "README.md"


### PR DESCRIPTION
Add an `--args-file` argument to `ddit run` to allow the user to select which integration argument metadata file to use, defaults to `int_args.yaml`.