### PR TITLE
Run formatters (black and isort) on the codebase.

### DIFF
--- a/daml_dit_ddit/__init__.py
+++ b/daml_dit_ddit/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 from .main import main

--- a/daml_dit_ddit/common.py
+++ b/daml_dit_ddit/common.py
@@ -1,40 +1,37 @@
+from __future__ import annotations
+
 import os
 import sys
-import semver
-
-from typing import Dict, Optional, NoReturn
-from daml_dit_api.package_metadata import \
-    CatalogInfo, \
-    DamlModelInfo
-import yaml
-
-from dacite import from_dict
-
 from dataclasses import asdict
-
 from hashlib import sha256
+from typing import Dict, NoReturn, Optional
 
-from daml_dit_api import \
-    DIT_META_KEY_NAME, \
-    DIT_META_NAMES, \
-    IntegrationTypeInfo, \
-    PackageMetadata, \
-    TAG_EXPERIMENTAL, \
-    normalize_package_metadata
+import semver
+import yaml
+from dacite import from_dict
+from daml_dit_api import (
+    DIT_META_KEY_NAME,
+    DIT_META_NAMES,
+    TAG_EXPERIMENTAL,
+    IntegrationTypeInfo,
+    PackageMetadata,
+    normalize_package_metadata,
+)
+from daml_dit_api.package_metadata import CatalogInfo, DamlModelInfo
 
 from .log import LOG
 
+DAML_YAML_NAME = "daml.yaml"
 
-DAML_YAML_NAME = 'daml.yaml'
+VIRTUAL_ENV_DIR = ".ddit-venv"
 
-VIRTUAL_ENV_DIR = '.ddit-venv'
+PYTHON_REQUIREMENT_FILE = "requirements.txt"
 
-PYTHON_REQUIREMENT_FILE = 'requirements.txt'
+INTEGRATION_ARG_FILE = "int_args.yaml"
 
-INTEGRATION_ARG_FILE = 'int_args.yaml'
 
-def die(message: str) -> 'NoReturn':
-    LOG.error(f'Fatal Error: {message}')
+def die(message: str) -> "NoReturn":
+    LOG.error(f"Fatal Error: {message}")
     sys.exit(9)
 
 
@@ -54,66 +51,72 @@ def daml_yaml_version():
     daml_yaml = load_daml_yaml()
 
     if daml_yaml is None:
-        die(f'{DAML_YAML_NAME} does not exist, cannot compute Daml model version.')
+        die(f"{DAML_YAML_NAME} does not exist, cannot compute Daml model version.")
 
-    LOG.debug(f'{DAML_YAML_NAME}: %r', daml_yaml)
+    LOG.debug(f"{DAML_YAML_NAME}: %r", daml_yaml)
 
-    if 'version' in daml_yaml:
-        version = daml_yaml['version']
-        LOG.info(f'Daml model version from {DAML_YAML_NAME}: %r', version)
+    if "version" in daml_yaml:
+        version = daml_yaml["version"]
+        LOG.info(f"Daml model version from {DAML_YAML_NAME}: %r", version)
         return version
     else:
-        die(f'No model version specified in {DAML_YAML_NAME}')
+        die(f"No model version specified in {DAML_YAML_NAME}")
 
 
-def accept_dabl_meta(yaml_data: Dict) -> 'PackageMetadata':
+def accept_dabl_meta(yaml_data: Dict) -> "PackageMetadata":
     try:
-        return from_dict(
-            data_class=PackageMetadata,
-            data=yaml_data)
+        return from_dict(data_class=PackageMetadata, data=yaml_data)
     except:
-        die(f'Package metadata does not match expected format.')
+        die(f"Package metadata does not match expected format.")
 
 
-def accept_dabl_meta_bytes(data: bytes) -> 'PackageMetadata':
+def accept_dabl_meta_bytes(data: bytes) -> "PackageMetadata":
     try:
         return accept_dabl_meta(yaml.safe_load(data))
     except:
-        die(f'Error parsing project metadata file.')
+        die(f"Error parsing project metadata file.")
 
 
-def with_catalog(dabl_meta: 'PackageMetadata') -> 'CatalogInfo':
+def with_catalog(dabl_meta: "PackageMetadata") -> "CatalogInfo":
     catalog = dabl_meta.catalog
 
     if catalog is None:
-        die('Missing catalog information in project metadata file.')
+        die("Missing catalog information in project metadata file.")
     else:
         try:
             semver.VersionInfo.parse(catalog.version)
         except ValueError:
-            die('Invalid version number in project metadata file: '
-                f' {catalog.version}')
+            die(
+                "Invalid version number in project metadata file: "
+                f" {catalog.version}"
+            )
 
         return catalog
 
 
-def _check_deprecated(dabl_meta: 'PackageMetadata'):
+def _check_deprecated(dabl_meta: "PackageMetadata"):
     catalog = with_catalog(dabl_meta)
 
     if catalog.experimental is not None:
-        LOG.warn((
-            f"The 'experimental' metadata field is deprecated, and support may be"
-            f" dropped in a future release. Please specify '{TAG_EXPERIMENTAL}'"
-            f" inside the project's tag list instead."))
+        LOG.warn(
+            (
+                f"The 'experimental' metadata field is deprecated, and support may be"
+                f" dropped in a future release. Please specify '{TAG_EXPERIMENTAL}'"
+                f" inside the project's tag list instead."
+            )
+        )
 
     if dabl_meta.integrations:
-        LOG.warn((
-            f"The 'integrations' metadata field is deprecated, and support may be"
-            f" dropped in a future release. Please use  'integration_types'"
-            f" instead."))
+        LOG.warn(
+            (
+                f"The 'integrations' metadata field is deprecated, and support may be"
+                f" dropped in a future release. Please use  'integration_types'"
+                f" instead."
+            )
+        )
 
 
-def load_dabl_meta() -> 'PackageMetadata':
+def load_dabl_meta() -> "PackageMetadata":
     raw_dabl_meta = None
 
     daml_yaml = load_daml_yaml()
@@ -121,9 +124,8 @@ def load_dabl_meta() -> 'PackageMetadata':
         dabl_meta_yaml = daml_yaml.get(DIT_META_KEY_NAME, None)
 
         if dabl_meta_yaml:
-            LOG.debug(f'Project metadata found in {DAML_YAML_NAME}')
+            LOG.debug(f"Project metadata found in {DAML_YAML_NAME}")
             raw_dabl_meta = accept_dabl_meta(dabl_meta_yaml)
-
 
     preferred_file_name = DIT_META_NAMES[0]
 
@@ -131,13 +133,17 @@ def load_dabl_meta() -> 'PackageMetadata':
         try:
             with open(file_name, "r") as f:
                 if raw_dabl_meta:
-                    die(f'Duplicate project metadata in file: {file_name}.'
-                        f' Please use only {preferred_file_name} or the {DIT_META_KEY_NAME}'
-                        f' key in {DAML_YAML_NAME}.')
+                    die(
+                        f"Duplicate project metadata in file: {file_name}."
+                        f" Please use only {preferred_file_name} or the {DIT_META_KEY_NAME}"
+                        f" key in {DAML_YAML_NAME}."
+                    )
                 elif file_name != preferred_file_name:
-                    LOG.warn(f'Storing project metadata in {file_name} is deprecated.'
-                             f' Please use {preferred_file_name}. or the {DIT_META_KEY_NAME}'
-                             f' key in {DAML_YAML_NAME}.')
+                    LOG.warn(
+                        f"Storing project metadata in {file_name} is deprecated."
+                        f" Please use {preferred_file_name}. or the {DIT_META_KEY_NAME}"
+                        f" key in {DAML_YAML_NAME}."
+                    )
 
                 raw_dabl_meta = accept_dabl_meta_bytes(f.read().encode())
 
@@ -148,74 +154,81 @@ def load_dabl_meta() -> 'PackageMetadata':
         _check_deprecated(raw_dabl_meta)
         return normalize_package_metadata(raw_dabl_meta)
 
-    die(f'Project metadata file not found: {DIT_META_NAMES}')
+    die(f"Project metadata file not found: {DIT_META_NAMES}")
 
 
 def package_meta_integration_types(
-        package_metadata: 'PackageMetadata') -> 'Dict[str, IntegrationTypeInfo]':
-
-    package_itypes = (package_metadata.integration_types
-                      or package_metadata.integrations  # support for deprecated
-                      or [])
+    package_metadata: "PackageMetadata",
+) -> "Dict[str, IntegrationTypeInfo]":
+    package_itypes = (
+        package_metadata.integration_types
+        or package_metadata.integrations  # support for deprecated
+        or []
+    )
 
     return {itype.id: itype for itype in package_itypes}
 
-def get_experimental(catalog: 'CatalogInfo'):
+
+def get_experimental(catalog: "CatalogInfo"):
     experimental = (TAG_EXPERIMENTAL in catalog.tags) or (catalog.experimental)
     if experimental is None:
         return False
     else:
         return experimental
 
-def package_dit_basename(dabl_meta: 'PackageMetadata') -> str:
-    catalog = with_catalog(dabl_meta)
-    return f'{catalog.name}-{catalog.version}'
 
-def package_dit_filename(dabl_meta: 'PackageMetadata') -> str:
+def package_dit_basename(dabl_meta: "PackageMetadata") -> str:
+    catalog = with_catalog(dabl_meta)
+    return f"{catalog.name}-{catalog.version}"
+
+
+def package_dit_filename(dabl_meta: "PackageMetadata") -> str:
     basename = package_dit_basename(dabl_meta)
 
-    return f'{basename}.dit'
+    return f"{basename}.dit"
 
 
-def show_integration_types(dabl_meta: 'PackageMetadata'):
+def show_integration_types(dabl_meta: "PackageMetadata"):
     itypes = package_meta_integration_types(dabl_meta)
 
     if len(itypes) > 0:
-        print('\nIntegration Types:')
+        print("\nIntegration Types:")
 
         for itype in itypes.values():
-            print(f'   {itype.id} - {itype.name}')
+            print(f"   {itype.id} - {itype.name}")
 
-def show_daml_model(daml_model: 'Optional[DamlModelInfo]'):
+
+def show_daml_model(daml_model: "Optional[DamlModelInfo]"):
     print()
 
     if daml_model:
-        print(f'Daml Model: ')
-        print(f'   Name/Version: {daml_model.name}:{daml_model.version}')
-        print(f'   Package ID: {daml_model.main_package_id}')
+        print(f"Daml Model: ")
+        print(f"   Name/Version: {daml_model.name}:{daml_model.version}")
+        print(f"   Package ID: {daml_model.main_package_id}")
     else:
-        print('No Daml model information present')
+        print("No Daml model information present")
 
-def show_package_summary(dabl_meta: 'PackageMetadata'):
-    print('Package Catalog:')
-    for (k, v) in asdict(dabl_meta.catalog).items():
-        print(f'   {k} : {v}')
+
+def show_package_summary(dabl_meta: "PackageMetadata"):
+    print("Package Catalog:")
+    for k, v in asdict(dabl_meta.catalog).items():
+        print(f"   {k} : {v}")
 
     show_daml_model(dabl_meta.daml_model)
 
     show_integration_types(dabl_meta)
 
-def package_meta_yaml(dabl_meta: 'PackageMetadata'):
-    return yaml.dump(
-        asdict(dabl_meta),
-        default_flow_style=True,
-        default_style='"')
+
+def package_meta_yaml(dabl_meta: "PackageMetadata"):
+    return yaml.dump(asdict(dabl_meta), default_flow_style=True, default_style='"')
+
 
 def read_binary_file(filename: str) -> bytes:
-    with open(filename, mode='rb') as file:
+    with open(filename, mode="rb") as file:
         file_contents = file.read()
 
     return file_contents
+
 
 def get_itype(integration_type_id):
     dabl_meta = load_dabl_meta()
@@ -227,7 +240,6 @@ def get_itype(integration_type_id):
     if itype is None:
         show_integration_types(dabl_meta)
         print()
-        die(f'Unknown integration type: {integration_type_id}\n')
-
+        die(f"Unknown integration type: {integration_type_id}\n")
 
     return itype

--- a/daml_dit_ddit/log.py
+++ b/daml_dit_ddit/log.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 
@@ -6,9 +8,9 @@ def setup_default_logging(**overrides):
     logging.Formatter.converter = time.gmtime
 
     defaults = {
-        'level': logging.INFO,
-        'format': '%(asctime)s [%(levelname)s] (%(name)s) %(message)s',
-        'datefmt': '%Y-%m-%dT%H:%M:%S%z'
+        "level": logging.INFO,
+        "format": "%(asctime)s [%(levelname)s] (%(name)s) %(message)s",
+        "datefmt": "%Y-%m-%dT%H:%M:%S%z",
     }
 
     config = {**defaults, **overrides}
@@ -16,7 +18,8 @@ def setup_default_logging(**overrides):
     logging.basicConfig(**config)
 
 
-LOG = logging.getLogger('ddit')
+LOG = logging.getLogger("ddit")
+
 
 def is_verbose():
     return logging.root.level <= logging.DEBUG

--- a/daml_dit_ddit/main.py
+++ b/daml_dit_ddit/main.py
@@ -1,13 +1,11 @@
+from __future__ import annotations
+
 import argparse
-
 import logging
-
-from typing import Union, List
-
-from .log import setup_default_logging, LOG
+from typing import List, Union
 
 from .common import die
-
+from .log import LOG, setup_default_logging
 from .subcommand_build import setup as setup_subcommand_build
 from .subcommand_clean import setup as setup_subcommand_clean
 from .subcommand_ditversion import setup as setup_subcommand_ditversion
@@ -21,55 +19,79 @@ from .subcommand_targetname import setup as setup_subcommand_targetname
 
 
 def main():
-
     parser = argparse.ArgumentParser()
-    parser.add_argument('--verbose', help='Turn on additional logging.',
-                        dest='verbose', action='store_true', default=False)
+    parser.add_argument(
+        "--verbose",
+        help="Turn on additional logging.",
+        dest="verbose",
+        action="store_true",
+        default=False,
+    )
 
-    subcommands={}
-    subparsers=parser.add_subparsers(dest='subcommand_name', help='subcommand')
+    subcommands = {}
+    subparsers = parser.add_subparsers(dest="subcommand_name", help="subcommand")
 
-    def install_subcommand(name_or_names: 'Union[str, List[str]]', help: str, setup_fn):
-        names = name_or_names if isinstance(name_or_names, list) else [ name_or_names ]
+    def install_subcommand(name_or_names: "Union[str, List[str]]", help: str, setup_fn):
+        names = name_or_names if isinstance(name_or_names, list) else [name_or_names]
 
         for name in names:
             cmd_fn = setup_fn(subparsers.add_parser(name, help=help))
             subcommands[name] = cmd_fn
 
-    install_subcommand("build", "Build a DIT file.",
-                       setup_subcommand_build)
+    install_subcommand("build", "Build a DIT file.", setup_subcommand_build)
 
-    install_subcommand("clean", "Resets the local build target and virtual environment to an empty state.",
-                       setup_subcommand_clean)
+    install_subcommand(
+        "clean",
+        "Resets the local build target and virtual environment to an empty state.",
+        setup_subcommand_clean,
+    )
 
-    install_subcommand("ditversion", "Print the current version in dabl-meta.yaml",
-                       setup_subcommand_ditversion)
+    install_subcommand(
+        "ditversion",
+        "Print the current version in dabl-meta.yaml",
+        setup_subcommand_ditversion,
+    )
 
-    install_subcommand("genargs", "Write a template integration argfile to stdout",
-                       setup_subcommand_genargs)
+    install_subcommand(
+        "genargs",
+        "Write a template integration argfile to stdout",
+        setup_subcommand_genargs,
+    )
 
-    install_subcommand("inspect", "Inspect the contents of a DIT file.",
-                       setup_subcommand_inspect)
+    install_subcommand(
+        "inspect", "Inspect the contents of a DIT file.", setup_subcommand_inspect
+    )
 
-    install_subcommand("install", "Install the DIT file's dependencies into a local virtual environment.",
-                       setup_subcommand_install)
+    install_subcommand(
+        "install",
+        "Install the DIT file's dependencies into a local virtual environment.",
+        setup_subcommand_install,
+    )
 
-    install_subcommand(["publish", "release"], "Tag and release the current DIT file.",
-                       setup_subcommand_release)
+    install_subcommand(
+        ["publish", "release"],
+        "Tag and release the current DIT file.",
+        setup_subcommand_release,
+    )
 
-    install_subcommand("run", "Run the current project as an integration.",
-                       setup_subcommand_run)
+    install_subcommand(
+        "run", "Run the current project as an integration.", setup_subcommand_run
+    )
 
-    install_subcommand("show", "Verify and print the current metadata file.",
-                       setup_subcommand_show)
+    install_subcommand(
+        "show", "Verify and print the current metadata file.", setup_subcommand_show
+    )
 
-    install_subcommand("targetname", "Print the build target filename to stdout",
-                       setup_subcommand_targetname)
+    install_subcommand(
+        "targetname",
+        "Print the build target filename to stdout",
+        setup_subcommand_targetname,
+    )
 
     kwargs = vars(parser.parse_args())
 
-    subcommand_name = kwargs.pop('subcommand_name')
-    verbose = kwargs.pop('verbose')
+    subcommand_name = kwargs.pop("subcommand_name")
+    verbose = kwargs.pop("verbose")
 
     setup_default_logging(level=logging.DEBUG if verbose else logging.INFO)
 
@@ -80,6 +102,8 @@ def main():
     else:
         parser.print_help()
 
-        die(f'Unknown subcommand: {subcommand_name}'
-            if subcommand_name else 'Subcommand missing.')
-
+        die(
+            f"Unknown subcommand: {subcommand_name}"
+            if subcommand_name
+            else "Subcommand missing."
+        )

--- a/daml_dit_ddit/subcommand_clean.py
+++ b/daml_dit_ddit/subcommand_clean.py
@@ -1,19 +1,15 @@
-import os
-import subprocess
-import shutil
+from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 from typing import Optional
 
-from .common import \
-    die, \
-    VIRTUAL_ENV_DIR, \
-    load_dabl_meta, \
-    package_dit_filename
-
+from .common import VIRTUAL_ENV_DIR, die, load_dabl_meta, package_dit_filename
 from .log import LOG
 
-def subcommand_main():
 
+def subcommand_main():
     if os.path.isdir(VIRTUAL_ENV_DIR):
         shutil.rmtree(VIRTUAL_ENV_DIR)
 

--- a/daml_dit_ddit/subcommand_ditversion.py
+++ b/daml_dit_ddit/subcommand_ditversion.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import semver
 
 from .common import die, load_dabl_meta, with_catalog
 
-def subcommand_main(
-        final_version: bool):
 
+def subcommand_main(final_version: bool):
     catalog = with_catalog(load_dabl_meta())
 
     version = semver.VersionInfo.parse(catalog.version)
@@ -16,7 +17,12 @@ def subcommand_main(
 
 
 def setup(sp):
-    sp.add_argument('--final-version', help='Render the version as MAJOR.MINOR.PATCH.',
-                    dest='final_version', action='store_true', default=False)
+    sp.add_argument(
+        "--final-version",
+        help="Render the version as MAJOR.MINOR.PATCH.",
+        dest="final_version",
+        action="store_true",
+        default=False,
+    )
 
     return subcommand_main

--- a/daml_dit_ddit/subcommand_genargs.py
+++ b/daml_dit_ddit/subcommand_genargs.py
@@ -1,46 +1,63 @@
+from __future__ import annotations
+
 import os
+
 from daml_dit_api import IntegrationTypeInfo
 
-from .common import \
-    show_integration_types, \
-    package_meta_integration_types, \
-    INTEGRATION_ARG_FILE
-
+from .common import (
+    INTEGRATION_ARG_FILE,
+    die,
+    get_itype,
+    package_meta_integration_types,
+    show_integration_types,
+)
 from .log import LOG
 
-from .common import die, get_itype
 
-def generate_argfile(integration_type: 'IntegrationTypeInfo', args_file: 'str'):
+def generate_argfile(integration_type: "IntegrationTypeInfo", args_file: "str"):
     with open(args_file, "w") as out:
-        out.write(f'# Arguments for integration type \'{integration_type.id}\'\n')
-        out.write('\n')
+        out.write(f"# Arguments for integration type '{integration_type.id}'\n")
+        out.write("\n")
         out.write('"metadata":\n')
         for field in integration_type.fields:
             out.write(f'    "{field.id.strip()}": "{field.field_type.strip()}"\n')
 
 
 def subcommand_main(integration_type_id: str, args_file: str, force: bool = False):
-
     if os.path.isfile(args_file):
         if force:
-            LOG.info(f'Forcibly overwriting existing integration argument file: {args_file}')
+            LOG.info(
+                f"Forcibly overwriting existing integration argument file: {args_file}"
+            )
             os.remove(args_file)
         else:
-            die(f'Integration argument file already exists: {args_file}')
+            die(f"Integration argument file already exists: {args_file}")
 
     generate_argfile(get_itype(integration_type_id), args_file)
 
-    LOG.info(f'Integration argument file created, please update with configuration'
-             f' values: {args_file}')
+    LOG.info(
+        f"Integration argument file created, please update with configuration"
+        f" values: {args_file}"
+    )
 
 
 def setup(sp):
-    sp.add_argument('integration_type_id', metavar='integration_type_id')
+    sp.add_argument("integration_type_id", metavar="integration_type_id")
 
-    sp.add_argument('--args-file', help=f'Use a specified arguments file, defaults to {INTEGRATION_ARG_FILE}.',
-                    dest='args_file', action='store', default=INTEGRATION_ARG_FILE)
+    sp.add_argument(
+        "--args-file",
+        help=f"Use a specified arguments file, defaults to {INTEGRATION_ARG_FILE}.",
+        dest="args_file",
+        action="store",
+        default=INTEGRATION_ARG_FILE,
+    )
 
-    sp.add_argument('--force', help='Forcibly overwrite argument file if it already exists.',
-                    dest='force', action='store_true', default=False)
+    sp.add_argument(
+        "--force",
+        help="Forcibly overwrite argument file if it already exists.",
+        dest="force",
+        action="store_true",
+        default=False,
+    )
 
     return subcommand_main

--- a/daml_dit_ddit/subcommand_inspect.py
+++ b/daml_dit_ddit/subcommand_inspect.py
@@ -1,52 +1,54 @@
+from __future__ import annotations
+
 import io
 import os
-
 from typing import Dict
 from zipfile import ZipFile
 
-from daml_dit_api import \
-    DIT_META_NAMES, \
-    PackageMetadata
+from daml_dit_api import DIT_META_NAMES, PackageMetadata
 
-from .common import \
-    die, \
-    artifact_hash, \
-    accept_dabl_meta_bytes, \
-    read_binary_file, \
-    show_package_summary
-
+from .common import (
+    accept_dabl_meta_bytes,
+    artifact_hash,
+    die,
+    read_binary_file,
+    show_package_summary,
+)
 from .log import LOG
 
 
-def show_subdeployments(dabl_meta: 'PackageMetadata', contents):
+def show_subdeployments(dabl_meta: "PackageMetadata", contents):
     subdeployments = dabl_meta.subdeployments
 
     if subdeployments is not None and len(subdeployments) > 0:
-        print('\nSubdeployments:')
+        print("\nSubdeployments:")
 
         for sd in subdeployments:
             sd_data = contents.get(sd)
 
-            status = "MISSING" if (sd_data is None) \
-                else f'{len(sd_data)} bytes, {artifact_hash(sd_data)}'
+            status = (
+                "MISSING"
+                if (sd_data is None)
+                else f"{len(sd_data)} bytes, {artifact_hash(sd_data)}"
+            )
 
-            print(f'   {sd} ({status})')
+            print(f"   {sd} ({status})")
     else:
-        print('\nSubdeployments: None')
+        print("\nSubdeployments: None")
 
 
 def subcommand_main(dit_filename: str):
     if not os.path.exists(dit_filename):
-        die(f'DIT file not found: {dit_filename}')
+        die(f"DIT file not found: {dit_filename}")
 
-    contents : Dict[str, bytes] = {}
+    contents: Dict[str, bytes] = {}
 
     dit_file_contents = read_binary_file(dit_filename)
 
-    print('Artifact hash: ', artifact_hash(dit_file_contents))
+    print("Artifact hash: ", artifact_hash(dit_file_contents))
     print()
 
-    with ZipFile(io.BytesIO(dit_file_contents), 'r') as ditfile:
+    with ZipFile(io.BytesIO(dit_file_contents), "r") as ditfile:
         filenames = set(ditfile.namelist())
 
         for zi in ditfile.infolist():
@@ -59,19 +61,21 @@ def subcommand_main(dit_filename: str):
 
         if meta_contents:
             if dabl_meta:
-                LOG.debug(f' Additional metadata subfile ignored: {subfile_name}. (This'
-                          f' is expected in DIT files built to be compatible with'
-                          f' both the old and new metadata filenames.)')
+                LOG.debug(
+                    f" Additional metadata subfile ignored: {subfile_name}. (This"
+                    f" is expected in DIT files built to be compatible with"
+                    f" both the old and new metadata filenames.)"
+                )
 
             dabl_meta = accept_dabl_meta_bytes(contents[subfile_name])
 
     if dabl_meta is None:
-        die(f'DIT file missing metadata ({DIT_META_NAMES[0]} missing): {dit_filename}')
+        die(f"DIT file missing metadata ({DIT_META_NAMES[0]} missing): {dit_filename}")
 
     show_package_summary(dabl_meta)
     show_subdeployments(dabl_meta, contents)
 
 
 def setup(sp):
-    sp.add_argument('dit_filename', metavar='dit_filename')
+    sp.add_argument("dit_filename", metavar="dit_filename")
     return subcommand_main

--- a/daml_dit_ddit/subcommand_install.py
+++ b/daml_dit_ddit/subcommand_install.py
@@ -1,66 +1,78 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import venv
-
 from typing import Optional
 
-from .common import \
-    die, \
-    PYTHON_REQUIREMENT_FILE, \
-    VIRTUAL_ENV_DIR
-
+from .common import PYTHON_REQUIREMENT_FILE, VIRTUAL_ENV_DIR, die
 from .log import LOG
 
 
 def install(cmd_suffix):
-    install_cmd = [ f'{VIRTUAL_ENV_DIR}/bin/pip3', 'install' ]
+    install_cmd = [f"{VIRTUAL_ENV_DIR}/bin/pip3", "install"]
 
     returncode = subprocess.run([*install_cmd, *cmd_suffix]).returncode
 
     if returncode != 0:
-        die(f'Error installing {cmd_suffix}')
+        die(f"Error installing {cmd_suffix}")
 
 
-def subcommand_main(force: bool, if_version: 'Optional[str]' = None, if_file: 'Optional[str]' = None):
-
+def subcommand_main(
+    force: bool, if_version: "Optional[str]" = None, if_file: "Optional[str]" = None
+):
     if os.path.isdir(VIRTUAL_ENV_DIR):
         if force:
-            LOG.info(f'Forcibly overwriting virtual environment: {VIRTUAL_ENV_DIR}')
+            LOG.info(f"Forcibly overwriting virtual environment: {VIRTUAL_ENV_DIR}")
         else:
-            die(f'Virtual environment already exists: {VIRTUAL_ENV_DIR}')
+            die(f"Virtual environment already exists: {VIRTUAL_ENV_DIR}")
     else:
-        LOG.info(f'Installing into virtual environment: {VIRTUAL_ENV_DIR}')
+        LOG.info(f"Installing into virtual environment: {VIRTUAL_ENV_DIR}")
 
     venv.EnvBuilder(with_pip=True, clear=force).create(VIRTUAL_ENV_DIR)
 
     if if_version and if_file:
-        die('Cannot specify both --if-version and --if-file')
+        die("Cannot specify both --if-version and --if-file")
 
     elif if_version:
-        LOG.info('Installing specific version of daml-dit-if from PyPi: %r', if_version)
-        install([f'daml_dit_if=={if_version}'])
+        LOG.info("Installing specific version of daml-dit-if from PyPi: %r", if_version)
+        install([f"daml_dit_if=={if_version}"])
 
     elif if_file:
-        LOG.info('Installing daml-dit-if from %r', if_file)
-        install([f'{if_file}'])
+        LOG.info("Installing daml-dit-if from %r", if_file)
+        install([f"{if_file}"])
 
     else:
-        LOG.info('Installing latest daml-dit-if from PyPi')
-        install(['daml_dit_if'])
+        LOG.info("Installing latest daml-dit-if from PyPi")
+        install(["daml_dit_if"])
 
     if os.path.isfile(PYTHON_REQUIREMENT_FILE):
-        install(['-r', 'requirements.txt'])
+        install(["-r", "requirements.txt"])
 
 
 def setup(sp):
+    sp.add_argument(
+        "--force",
+        help="Forcibly overwrite the virtual environment if it exists.",
+        dest="force",
+        action="store_true",
+        default=False,
+    )
 
-    sp.add_argument('--force', help='Forcibly overwrite the virtual environment if it exists.',
-                    dest='force', action='store_true', default=False)
+    sp.add_argument(
+        "--if-version",
+        help="Use a specific version of daml-dit-if.",
+        dest="if_version",
+        action="store",
+        default=None,
+    )
 
-    sp.add_argument('--if-version', help='Use a specific version of daml-dit-if.',
-                    dest='if_version', action='store', default=None)
-
-    sp.add_argument('--if-file', help='Use a specific file source for daml-dit-if.',
-                    dest='if_file', action='store', default=None)
+    sp.add_argument(
+        "--if-file",
+        help="Use a specific file source for daml-dit-if.",
+        dest="if_file",
+        action="store",
+        default=None,
+    )
 
     return subcommand_main

--- a/daml_dit_ddit/subcommand_run.py
+++ b/daml_dit_ddit/subcommand_run.py
@@ -1,40 +1,39 @@
+from __future__ import annotations
+
 import os
 import subprocess
 from dataclasses import replace
-
 from typing import Optional
 
-from .common import \
-    die, \
-    get_itype, \
-    load_dabl_meta, \
-    package_meta_yaml, \
-    INTEGRATION_ARG_FILE, \
-    VIRTUAL_ENV_DIR
-
-from .subcommand_build import build_dar
-from .subcommand_install import subcommand_main as subcommand_install
-from .subcommand_genargs import subcommand_main as subcommand_genargs
-
+from .common import (
+    INTEGRATION_ARG_FILE,
+    VIRTUAL_ENV_DIR,
+    die,
+    get_itype,
+    load_dabl_meta,
+    package_meta_yaml,
+)
 from .log import LOG
+from .subcommand_build import build_dar
+from .subcommand_genargs import subcommand_main as subcommand_genargs
+from .subcommand_install import subcommand_main as subcommand_install
 
+RUNTIME_DIT_META_NAME = ".ddit-dit-meta.yaml"
 
-RUNTIME_DIT_META_NAME = '.ddit-dit-meta.yaml'
 
 def subcommand_main(
-        integration_type_id: str,
-        log_level: 'Optional[str]',
-        party: 'str',
-        if_version: 'Optional[str]',
-        if_file: 'Optional[str]',
-        args_file: 'str',
-        ledger_url: 'Optional[str]',
-        rebuild_dar: bool):
-
+    integration_type_id: str,
+    log_level: "Optional[str]",
+    party: "str",
+    if_version: "Optional[str]",
+    if_file: "Optional[str]",
+    args_file: "str",
+    ledger_url: "Optional[str]",
+    rebuild_dar: bool,
+):
     # Ensure that the integration type is known, and print a useful error
     # message if not.
     get_itype(integration_type_id)
-
 
     dabl_meta = load_dabl_meta()
 
@@ -43,19 +42,17 @@ def subcommand_main(
     if dar_build_result:
         (dar_filename, daml_model_info) = dar_build_result
 
-        dabl_meta = replace(
-            dabl_meta,
-            daml_model=daml_model_info)
+        dabl_meta = replace(dabl_meta, daml_model=daml_model_info)
 
-    with open(RUNTIME_DIT_META_NAME, 'w') as runtime_meta_file:
+    with open(RUNTIME_DIT_META_NAME, "w") as runtime_meta_file:
         runtime_meta_file.write(package_meta_yaml(dabl_meta))
 
     if os.path.isfile(args_file):
-        LOG.info(f'Argument file found: {args_file}')
+        LOG.info(f"Argument file found: {args_file}")
     else:
-        LOG.info(f'Argument file not found: {args_file}')
+        LOG.info(f"Argument file not found: {args_file}")
         subcommand_genargs(integration_type_id, args_file)
-        die('Cannot run integration with un-edited argument file.')
+        die("Cannot run integration with un-edited argument file.")
 
     if if_file or if_version:
         # Forcibly ensure the use of a specific version of
@@ -70,45 +67,83 @@ def subcommand_main(
         LOG.info("Virtual environment missing, installing now.")
         subcommand_install(False)
 
-    url_dict = { 'DABL_LEDGER_URL': ledger_url } if ledger_url else {}
+    url_dict = {"DABL_LEDGER_URL": ledger_url} if ledger_url else {}
     env = {
         **os.environ,
         **url_dict,
-        'PYTHONPATH': 'src',
-        'DABL_INTEGRATION_TYPE_ID': integration_type_id,
-        'DABL_INTEGRATION_METADATA_PATH': args_file,
-        'DAML_DIT_META_PATH': RUNTIME_DIT_META_NAME,
-        'DAML_LEDGER_PARTY': party
+        "PYTHONPATH": "src",
+        "DABL_INTEGRATION_TYPE_ID": integration_type_id,
+        "DABL_INTEGRATION_METADATA_PATH": args_file,
+        "DAML_DIT_META_PATH": RUNTIME_DIT_META_NAME,
+        "DAML_LEDGER_PARTY": party,
     }
 
     if log_level:
-        env['DABL_LOG_LEVEL'] = log_level
+        env["DABL_LOG_LEVEL"] = log_level
 
-    subprocess.run([f'{VIRTUAL_ENV_DIR}/bin/python3', '-m', 'daml_dit_if.main'], env=env)
+    subprocess.run(
+        [f"{VIRTUAL_ENV_DIR}/bin/python3", "-m", "daml_dit_if.main"], env=env
+    )
 
 
 def setup(sp):
-    sp.add_argument('integration_type_id', metavar='integration_type_id')
+    sp.add_argument("integration_type_id", metavar="integration_type_id")
 
-    sp.add_argument('--party', help='Specify the run as party for the integration.',
-                    dest='party', action='store', default=None, required=True)
+    sp.add_argument(
+        "--party",
+        help="Specify the run as party for the integration.",
+        dest="party",
+        action="store",
+        default=None,
+        required=True,
+    )
 
-    sp.add_argument('--log-level', help='Set integration log level',
-                    dest='log_level', action='store', default=None)
+    sp.add_argument(
+        "--log-level",
+        help="Set integration log level",
+        dest="log_level",
+        action="store",
+        default=None,
+    )
 
-    sp.add_argument('--rebuild-dar', help='Rebuild and overwrite the DAR if it already exists',
-                    dest='rebuild_dar', action='store_true', default=False)
+    sp.add_argument(
+        "--rebuild-dar",
+        help="Rebuild and overwrite the DAR if it already exists",
+        dest="rebuild_dar",
+        action="store_true",
+        default=False,
+    )
 
-    sp.add_argument('--if-version', help='Ensure the integration is run with a specific daml-dit-if, by version.',
-                    dest='if_version', action='store', default=None)
+    sp.add_argument(
+        "--if-version",
+        help="Ensure the integration is run with a specific daml-dit-if, by version.",
+        dest="if_version",
+        action="store",
+        default=None,
+    )
 
-    sp.add_argument('--if-file', help='Ensure the integration is run with a specific daml-dit-if, by file.',
-                    dest='if_file', action='store', default=None)
+    sp.add_argument(
+        "--if-file",
+        help="Ensure the integration is run with a specific daml-dit-if, by file.",
+        dest="if_file",
+        action="store",
+        default=None,
+    )
 
-    sp.add_argument('--args-file', help=f'Use a specified arguments file, defaults to {INTEGRATION_ARG_FILE}.',
-                    dest='args_file', action='store', default=INTEGRATION_ARG_FILE)
+    sp.add_argument(
+        "--args-file",
+        help=f"Use a specified arguments file, defaults to {INTEGRATION_ARG_FILE}.",
+        dest="args_file",
+        action="store",
+        default=INTEGRATION_ARG_FILE,
+    )
 
-    sp.add_argument('--ledger-url', help='The URL of the ledger to connect to.',
-                    dest='ledger_url', action='store', default=None)
+    sp.add_argument(
+        "--ledger-url",
+        help="The URL of the ledger to connect to.",
+        dest="ledger_url",
+        action="store",
+        default=None,
+    )
 
     return subcommand_main

--- a/daml_dit_ddit/subcommand_show.py
+++ b/daml_dit_ddit/subcommand_show.py
@@ -1,6 +1,6 @@
-from .common import \
-    load_dabl_meta, \
-    show_package_summary
+from __future__ import annotations
+
+from .common import load_dabl_meta, show_package_summary
 
 
 def subcommand_main():

--- a/daml_dit_ddit/subcommand_targetname.py
+++ b/daml_dit_ddit/subcommand_targetname.py
@@ -1,7 +1,6 @@
-from .common import \
-    load_dabl_meta, \
-    package_dit_basename, \
-    package_dit_filename
+from __future__ import annotations
+
+from .common import load_dabl_meta, package_dit_basename, package_dit_filename
 
 
 def subcommand_main(basename: bool):
@@ -12,6 +11,11 @@ def subcommand_main(basename: bool):
 
 
 def setup(sp):
-    sp.add_argument('--basename', help='Return the base name only, without filename extension.',
-                    dest='basename', action='store_true', default=False)
+    sp.add_argument(
+        "--basename",
+        help="Return the base name only, without filename extension.",
+        dest="basename",
+        action="store_true",
+        default=False,
+    )
     return subcommand_main


### PR DESCRIPTION
_Just_ run `black` and `isort` on the codebase.

Nothing in the build enforces this yet, and none of the `Makefile` shenanigans are in place yet. I just wanted to get this out of the way because of the sheer number of files it touches when I do that.